### PR TITLE
Reset index when items are changed

### DIFF
--- a/powerspinner/src/main/java/com/skydoves/powerspinner/IconSpinnerAdapter.kt
+++ b/powerspinner/src/main/java/com/skydoves/powerspinner/IconSpinnerAdapter.kt
@@ -65,6 +65,7 @@ class IconSpinnerAdapter(
   override fun setItems(itemList: List<IconSpinnerItem>) {
     this.spinnerItems.clear()
     this.spinnerItems.addAll(itemList)
+    this.index = NO_SELECTED_INDEX
     notifyDataSetChanged()
   }
 


### PR DESCRIPTION
Bugfix (non-breaking change which fixes an issue): https://github.com/skydoves/PowerSpinner/issues/66.

This issue was already resolved but it was only fixed in the DefaultSpinnerAdapter. In this one-line PR the IconSpinnerAdapter has been fixed as well.