### PR TITLE
Fix memory leak issue

### DIFF
--- a/powerspinner/src/main/java/com/skydoves/powerspinner/PowerSpinnerView.kt
+++ b/powerspinner/src/main/java/com/skydoves/powerspinner/PowerSpinnerView.kt
@@ -235,7 +235,9 @@ class PowerSpinnerView : AppCompatTextView, LifecycleObserver {
    */
   var lifecycleOwner: LifecycleOwner? = null
     set(value) {
+      field?.lifecycle?.removeObserver(this@PowerSpinnerView)
       field = value
+      field?.lifecycle?.addObserver(this@PowerSpinnerView)
     }
 
   init {
@@ -764,6 +766,8 @@ class PowerSpinnerView : AppCompatTextView, LifecycleObserver {
   @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
   fun onDestroy() {
     dismiss()
+    
+    field?.lifecycle?.removeObserver(this@PowerSpinnerView)
   }
 
   /** Builder class for creating [PowerSpinnerView]. */

--- a/powerspinner/src/main/java/com/skydoves/powerspinner/PowerSpinnerView.kt
+++ b/powerspinner/src/main/java/com/skydoves/powerspinner/PowerSpinnerView.kt
@@ -236,7 +236,6 @@ class PowerSpinnerView : AppCompatTextView, LifecycleObserver {
   var lifecycleOwner: LifecycleOwner? = null
     set(value) {
       field = value
-      field?.lifecycle?.addObserver(this@PowerSpinnerView)
     }
 
   init {

--- a/powerspinner/src/main/java/com/skydoves/powerspinner/PowerSpinnerView.kt
+++ b/powerspinner/src/main/java/com/skydoves/powerspinner/PowerSpinnerView.kt
@@ -767,7 +767,7 @@ class PowerSpinnerView : AppCompatTextView, LifecycleObserver {
   fun onDestroy() {
     dismiss()
     
-    field?.lifecycle?.removeObserver(this@PowerSpinnerView)
+    lifecycleOwner?.lifecycle?.removeObserver(this@PowerSpinnerView)
   }
 
   /** Builder class for creating [PowerSpinnerView]. */


### PR DESCRIPTION
As described in `https://github.com/skydoves/PowerSpinner/issues/105` I have memory leak issues when using a PowerSpinnerView.

I think this issue is caused because of the observers that are being added to the lifecycle, but not removed when updating 'lifecycleOwner' or destroying the view.

I've tested this for my project and it seems to fix the issue. Note: It is only fixed when I set the 'lifecycleOwner' myself:
```
powerSpinnerView.lifecycleOwner = <MyView>.findViewTreeLifecycleOwner()
```

Without setting it I still get a memory leak notification from LeakCanary. I think this is because of the `lifecycleOwner` that is being used at line 277. But I'm no expert on that part, so I might be wrong.
`https://github.com/skydoves/PowerSpinner/blob/main/powerspinner/src/main/kotlin/com/skydoves/powerspinner/PowerSpinnerView.kt#L277`.