### PR TITLE
Fix memory leak issues

### DIFF
--- a/powerspinner/src/main/kotlin/com/skydoves/powerspinner/PowerSpinnerView.kt
+++ b/powerspinner/src/main/kotlin/com/skydoves/powerspinner/PowerSpinnerView.kt
@@ -827,7 +827,7 @@ public class PowerSpinnerView : AppCompatTextView, DefaultLifecycleObserver {
     super.onDestroy(owner)
     dismiss()
     
-    lifecycleOwner?.lifecycle?.removeObserver(this)
+    lifecycleOwner?.lifecycle?.removeObserver(this@PowerSpinnerView)
   }
 
   /** Builder class for creating [PowerSpinnerView]. */

--- a/powerspinner/src/main/kotlin/com/skydoves/powerspinner/PowerSpinnerView.kt
+++ b/powerspinner/src/main/kotlin/com/skydoves/powerspinner/PowerSpinnerView.kt
@@ -255,6 +255,7 @@ public class PowerSpinnerView : AppCompatTextView, DefaultLifecycleObserver {
    */
   public var lifecycleOwner: LifecycleOwner? = null
     set(value) {
+      field?.lifecycle?.removeObserver(this@PowerSpinnerView)
       field = value
       field?.lifecycle?.addObserver(this@PowerSpinnerView)
     }
@@ -825,6 +826,8 @@ public class PowerSpinnerView : AppCompatTextView, DefaultLifecycleObserver {
   override fun onDestroy(owner: LifecycleOwner) {
     super.onDestroy(owner)
     dismiss()
+    
+    lifecycleOwner?.lifecycle?.removeObserver(this)
   }
 
   /** Builder class for creating [PowerSpinnerView]. */

--- a/powerspinner/src/main/kotlin/com/skydoves/powerspinner/PowerSpinnerView.kt
+++ b/powerspinner/src/main/kotlin/com/skydoves/powerspinner/PowerSpinnerView.kt
@@ -826,7 +826,6 @@ public class PowerSpinnerView : AppCompatTextView, DefaultLifecycleObserver {
   override fun onDestroy(owner: LifecycleOwner) {
     super.onDestroy(owner)
     dismiss()
-    
     lifecycleOwner?.lifecycle?.removeObserver(this@PowerSpinnerView)
   }
 


### PR DESCRIPTION
As described in https://github.com/skydoves/PowerSpinner/issues/105 I have memory leak issues when using a PowerSpinnerView.

I think this issue is caused because of the observers that are being added to the lifecycle, but not removed when updating 'lifecycleOwner' or destroying the view.

I've tested this for my project and it seems to fix the issue. Note: It is only fixed when I set the 'lifecycleOwner' myself:

```
powerSpinnerView.lifecycleOwner = MyView.findViewTreeLifecycleOwner()
```

Without setting it I still get a memory leak notification from LeakCanary. I think this is because of the lifecycleOwner that is being used at line 277. But I'm no expert on that part, so I might be wrong.
https://github.com/skydoves/PowerSpinner/blob/main/powerspinner/src/main/kotlin/com/skydoves/powerspinner/PowerSpinnerView.kt#L277.